### PR TITLE
Hide fork ribbon for mobile users

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -122,3 +122,10 @@ footer li, footer li a {
     opacity: 1;
     filter: alpha(opacity=100);
 }
+
+/* Hide fork ribbon for mobile users */
+@media (max-width: 850px) {
+    .container > a {
+        display: none;
+    }
+}


### PR DESCRIPTION
Hide the fork ribbon for mobile users because it overlaps with the mobile menu and the title of the first article.