### PR TITLE
Feat/add litellm provider

### DIFF
--- a/config.py
+++ b/config.py
@@ -81,6 +81,11 @@ openai_score_threshold = int_env('OPENAI_SCORE_THRESHOLD', 20)
 local_llm_score_threshold = 10
 logger.info(f'Use openai model {openai_model}')
 
+litellm_model = os.getenv('LITELLM_MODEL') or ''
+litellm_api_key = os.getenv('LITELLM_API_KEY') or ''
+if litellm_model:
+    logger.info(f'Use litellm model {litellm_model}')
+
 disable_translation = os.getenv('DISABLE_TRANSLATION') == '1'
 
 output_dir = os.path.join(os.path.dirname(__file__), 'output/')

--- a/config.py
+++ b/config.py
@@ -83,8 +83,11 @@ logger.info(f'Use openai model {openai_model}')
 
 litellm_model = os.getenv('LITELLM_MODEL') or ''
 litellm_api_key = os.getenv('LITELLM_API_KEY') or ''
+litellm_api_base = os.getenv('LITELLM_API_BASE') or ''
 if litellm_model:
     logger.info(f'Use litellm model {litellm_model}')
+if litellm_api_base:
+    logger.info(f'Use litellm api base {litellm_api_base}')
 
 disable_translation = os.getenv('DISABLE_TRANSLATION') == '1'
 

--- a/db/summary.py
+++ b/db/summary.py
@@ -23,6 +23,7 @@ class Model(Enum):
     GEMMA = 'Gemma'
     QWEN = 'Qwen'
     OPENAI = 'OpenAI'
+    LITELLM = 'LiteLLM'
 
     def can_truncate(self):
         return self not in (Model.OPENAI, Model.EMBED)
@@ -31,10 +32,10 @@ class Model(Enum):
         return self in (Model.LLAMA, Model.TRANSFORMER)
 
     def is_final(self) -> bool:  # already good enough, no need to try other models
-        return self in (Model.EMBED, Model.OPENAI, Model.GEMMA, Model.LLAMA, Model.STEP, Model.QWEN)
+        return self in (Model.EMBED, Model.OPENAI, Model.GEMMA, Model.LLAMA, Model.STEP, Model.QWEN, Model.LITELLM)
 
     def need_escape(self):
-        return self in (Model.OPENAI, Model.GEMMA, Model.LLAMA, Model.QWEN)
+        return self in (Model.OPENAI, Model.GEMMA, Model.LLAMA, Model.QWEN, Model.LITELLM)
 
     @classmethod
     def from_value(cls, value):

--- a/hacker_news/llm/litellm.py
+++ b/hacker_news/llm/litellm.py
@@ -75,6 +75,8 @@ def call_litellm(content: str, sys_prompt: str, clean_fn=None) -> str:
     }
     if config.litellm_api_key:
         kwargs['api_key'] = config.litellm_api_key
+    if config.litellm_api_base:
+        kwargs['api_base'] = config.litellm_api_base
 
     try:
         resp = litellm.completion(**kwargs)

--- a/hacker_news/llm/litellm.py
+++ b/hacker_news/llm/litellm.py
@@ -4,7 +4,6 @@ import re
 import time
 
 import config
-from hacker_news.llm.openai import sanitize_for_openai
 
 logger = logging.getLogger(__name__)
 
@@ -19,14 +18,48 @@ def _import_litellm():
         )
 
 
-def call_litellm(content: str, sys_prompt: str) -> str:
+def _truncate_content(text: str, max_chars: int = 30000) -> str:
+    """Simple content truncation. Unlike sanitize_for_openai, this doesn't
+    depend on the openai SDK's global state (api_base)."""
+    text = text.replace('```', ' ').strip()
+    if len(text) > max_chars:
+        text = text[:max_chars]
+    return text.strip('.').strip()
+
+
+def _clean_summary(answer: str) -> str:
+    """Clean up a summarization response (English-only output expected)."""
+    if '</think>' in answer:
+        answer = answer.split('</think>', 1)[-1].strip()
+    for line in answer.split('\n'):
+        if not line.strip():
+            continue
+        if 'summary' in line.lower() and line.strip()[-1] == ':':
+            continue
+        answer = line
+        break
+    answer = re.sub(r'^[^a-zA-Z0-9]+', '', answer)
+    answer = answer.replace('**', ' ')
+    answer = re.sub(r'^summary:?', '', answer, flags=re.IGNORECASE)
+    return answer.strip()
+
+
+def _clean_translation(answer: str) -> str:
+    """Clean up a translation response (preserves non-Latin characters)."""
+    if '</think>' in answer:
+        answer = answer.split('</think>', 1)[-1].strip()
+    answer = answer.replace('**', ' ')
+    return answer.strip()
+
+
+def call_litellm(content: str, sys_prompt: str, clean_fn=None) -> str:
     litellm = _import_litellm()
 
     if not config.litellm_model:
         raise ValueError("LITELLM_MODEL environment variable is not set")
 
     start_time = time.time()
-    content = sanitize_for_openai(content, overhead=200)
+    content = _truncate_content(content)
 
     kwargs = {
         'model': config.litellm_model,
@@ -78,28 +111,23 @@ def call_litellm(content: str, sys_prompt: str) -> str:
         logger.warning('LiteLLM returned empty content')
         return ''
 
-    if '</think>' in answer:
-        answer = answer.split('</think>', 1)[-1].strip()
-    for line in answer.split('\n'):
-        if not line.strip():
-            continue
-        if 'summary' in line.lower() and line.strip()[-1] == ':':
-            continue
-        answer = line
-        break
-    answer = re.sub(r'^[^a-zA-Z0-9]+', '', answer)
-    answer = answer.replace('**', ' ')
-    answer = re.sub(r'^summary:?', '', answer, flags=re.IGNORECASE)
-    return answer.strip()
+    if clean_fn:
+        return clean_fn(answer)
+    return answer
 
 
 def summarize_by_litellm(content: str) -> str:
     return call_litellm(
         content,
         "You are a helpful summarizer. Please think step by step to summarize all user's input in 2 concise English sentences. Ensure the summary does not exceed 250 "
-        "characters. Provide response in plain text format without any Markdown formatting."
+        "characters. Provide response in plain text format without any Markdown formatting.",
+        clean_fn=_clean_summary,
     )
 
 
 def translate_by_litellm(content: str, lang: str) -> str:
-    return call_litellm(content, f"You are a helpful translator. Translate user's input into {lang}.")
+    return call_litellm(
+        content,
+        f"You are a helpful translator. Translate user's input into {lang}.",
+        clean_fn=_clean_translation,
+    )

--- a/hacker_news/llm/litellm.py
+++ b/hacker_news/llm/litellm.py
@@ -1,0 +1,65 @@
+import json
+import logging
+import re
+import time
+
+import config
+from hacker_news.llm.openai import sanitize_for_openai
+
+logger = logging.getLogger(__name__)
+
+
+def call_litellm(content: str, sys_prompt: str) -> str:
+    import litellm
+
+    start_time = time.time()
+    content = sanitize_for_openai(content, overhead=200)
+
+    kwargs = {
+        'model': config.litellm_model,
+        'messages': [
+            {'role': 'system', 'content': sys_prompt},
+            {'role': 'user', 'content': content},
+        ],
+        'stream': False,
+        'temperature': 0,
+        'n': 1,
+        'timeout': 30,
+        'drop_params': True,
+    }
+    if config.litellm_api_key:
+        kwargs['api_key'] = config.litellm_api_key
+
+    resp = litellm.completion(**kwargs)
+    resp_dict = resp.model_dump()
+
+    logger.warning(f'took {time.time() - start_time}s to generate: '
+                   f'{json.dumps(resp_dict, sort_keys=True, indent=2, ensure_ascii=False)}')
+
+    message = resp_dict['choices'][0]['message']
+    answer = message.get('content', '').strip()
+    if '</think>' in answer:
+        answer = answer.split('</think>', 1)[-1].strip()
+    for line in answer.split('\n'):
+        if not line.strip():
+            continue
+        if 'summary' in line.lower() and line.strip()[-1] == ':':
+            continue
+        answer = line
+        break
+    answer = re.sub(r'^[^a-zA-Z0-9]+', '', answer)
+    answer = answer.replace('**', ' ')
+    answer = re.sub(r'^summary:?', '', answer, flags=re.IGNORECASE)
+    return answer.strip()
+
+
+def summarize_by_litellm(content: str) -> str:
+    return call_litellm(
+        content,
+        "You are a helpful summarizer. Please think step by step to summarize all user's input in 2 concise English sentences. Ensure the summary does not exceed 250 "
+        "characters. Provide response in plain text format without any Markdown formatting."
+    )
+
+
+def translate_by_litellm(content: str, lang: str) -> str:
+    return call_litellm(content, f"You are a helpful translator. Translate user's input into {lang}.")

--- a/hacker_news/llm/litellm.py
+++ b/hacker_news/llm/litellm.py
@@ -9,8 +9,21 @@ from hacker_news.llm.openai import sanitize_for_openai
 logger = logging.getLogger(__name__)
 
 
+def _import_litellm():
+    try:
+        import litellm
+        return litellm
+    except ImportError:
+        raise ImportError(
+            "litellm is required. Install it with: pip install 'litellm>=1.83.0'"
+        )
+
+
 def call_litellm(content: str, sys_prompt: str) -> str:
-    import litellm
+    litellm = _import_litellm()
+
+    if not config.litellm_model:
+        raise ValueError("LITELLM_MODEL environment variable is not set")
 
     start_time = time.time()
     content = sanitize_for_openai(content, overhead=200)
@@ -30,14 +43,41 @@ def call_litellm(content: str, sys_prompt: str) -> str:
     if config.litellm_api_key:
         kwargs['api_key'] = config.litellm_api_key
 
-    resp = litellm.completion(**kwargs)
+    try:
+        resp = litellm.completion(**kwargs)
+    except litellm.AuthenticationError as e:
+        logger.error(f'LiteLLM authentication failed: {e}')
+        raise
+    except litellm.NotFoundError as e:
+        logger.error(f'LiteLLM model not found: {e}')
+        raise
+    except litellm.RateLimitError as e:
+        logger.warning(f'LiteLLM rate limited: {e}')
+        raise
+    except litellm.Timeout as e:
+        logger.error(f'LiteLLM request timed out: {e}')
+        raise
+    except litellm.APIConnectionError as e:
+        logger.error(f'LiteLLM connection error: {e}')
+        raise
+
     resp_dict = resp.model_dump()
 
     logger.warning(f'took {time.time() - start_time}s to generate: '
                    f'{json.dumps(resp_dict, sort_keys=True, indent=2, ensure_ascii=False)}')
 
-    message = resp_dict['choices'][0]['message']
-    answer = message.get('content', '').strip()
+    choices = resp_dict.get('choices', [])
+    if not choices:
+        logger.error('LiteLLM returned empty choices')
+        return ''
+
+    message = choices[0].get('message', {})
+    answer = (message.get('content') or '').strip()
+
+    if not answer:
+        logger.warning('LiteLLM returned empty content')
+        return ''
+
     if '</think>' in answer:
         answer = answer.split('</think>', 1)[-1].strip()
     for line in answer.split('\n'):

--- a/hacker_news/news.py
+++ b/hacker_news/news.py
@@ -12,6 +12,7 @@ import db.summary
 from db.summary import Model
 from hacker_news.llm.coze import summarize_by_coze
 from hacker_news.llm.openai import summarize_by_openai_family, model_family, translate_by_openai_family
+from hacker_news.llm.litellm import summarize_by_litellm, translate_by_litellm
 from page_content_extractor import parser_factory
 from page_content_extractor.webimage import WebImage
 
@@ -107,6 +108,9 @@ class News:
                 f'No need to summarize since we have a small text of size {len(content)}')
             return content, Model.FULL
 
+        summary = self.summarize_by_litellm_provider(content)
+        if summary:
+            return summary, Model.LITELLM
         summary = self.summarize_by_openai(content)
         if summary:
             return summary, model_family()
@@ -123,6 +127,34 @@ class News:
         else:
             logger.info("Score %d is too small, ignore local llm", self.get_score())
         return content, Model.PREFIX
+
+    def summarize_by_litellm_provider(self, content):
+        if not config.litellm_model:
+            return ''
+        try:
+            summary = summarize_by_litellm(content)
+            self.translate_by_litellm_provider(summary)
+            return summary
+        except Exception as e:
+            logger.exception(f'Failed to summarize using litellm, {e}')
+            return ''
+
+    def translate_by_litellm_provider(self, summary: str):
+        if not summary or config.disable_translation:
+            return
+        try:
+            if db.translation.exists(summary, 'zh'):
+                return
+            trans = translate_by_litellm(summary, 'simplified Chinese')
+            for char in trans:
+                if '一' <= char <= '鿿':
+                    break
+            else:
+                logger.info(f'No Chinese chars in translation: {trans}')
+                return
+            db.translation.add(summary, trans, 'zh')
+        except Exception as e:
+            logger.exception(f'Failed to translate using litellm, {e}')
 
     def summarize_by_coze(self, content):
         if self.get_score() < config.local_llm_score_threshold:

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,3 +25,4 @@ psycopg2==2.9.9
 humanize==4.8.0
 llama-cpp-python==0.2.11
 tiktoken==0.5.2
+litellm>=1.83.0,<2.0

--- a/test/test_litellm_provider.py
+++ b/test/test_litellm_provider.py
@@ -42,8 +42,7 @@ class LiteLLMProviderTestCase(TestCase):
         config.litellm_model = "openai/gpt-4o-mini"
         config.litellm_api_key = ""
 
-    @patch("hacker_news.llm.litellm.sanitize_for_openai", side_effect=lambda c, **kw: c)
-    def test_basic_summarize(self, _mock_sanitize):
+    def test_basic_summarize(self):
         import litellm
         with patch.object(litellm, "completion", return_value=_mock_response("Scientists discovered a new particle.")):
             from hacker_news.llm.litellm import summarize_by_litellm
@@ -53,8 +52,7 @@ class LiteLLMProviderTestCase(TestCase):
             call_kwargs = litellm.completion.call_args[1]
             self.assertEqual(call_kwargs["model"], "openai/gpt-4o-mini")
 
-    @patch("hacker_news.llm.litellm.sanitize_for_openai", side_effect=lambda c, **kw: c)
-    def test_translate_system_prompt(self, _mock_sanitize):
+    def test_translate_system_prompt(self):
         import litellm
         with patch.object(litellm, "completion", return_value=_mock_response("Translated text")):
             from hacker_news.llm.litellm import translate_by_litellm
@@ -62,16 +60,14 @@ class LiteLLMProviderTestCase(TestCase):
             sys_msg = litellm.completion.call_args[1]["messages"][0]
             self.assertIn("simplified Chinese", sys_msg["content"])
 
-    @patch("hacker_news.llm.litellm.sanitize_for_openai", side_effect=lambda c, **kw: c)
-    def test_drop_params_always_true(self, _mock_sanitize):
+    def test_drop_params_always_true(self):
         import litellm
         with patch.object(litellm, "completion", return_value=_mock_response("ok")):
             from hacker_news.llm.litellm import call_litellm
             call_litellm("content", "system prompt")
             self.assertTrue(litellm.completion.call_args[1]["drop_params"])
 
-    @patch("hacker_news.llm.litellm.sanitize_for_openai", side_effect=lambda c, **kw: c)
-    def test_api_key_forwarded(self, _mock_sanitize):
+    def test_api_key_forwarded(self):
         import config
         config.litellm_api_key = "sk-test-key"
         import litellm
@@ -80,30 +76,26 @@ class LiteLLMProviderTestCase(TestCase):
             call_litellm("content", "prompt")
             self.assertEqual(litellm.completion.call_args[1]["api_key"], "sk-test-key")
 
-    @patch("hacker_news.llm.litellm.sanitize_for_openai", side_effect=lambda c, **kw: c)
-    def test_api_key_omitted_when_empty(self, _mock_sanitize):
+    def test_api_key_omitted_when_empty(self):
         import litellm
         with patch.object(litellm, "completion", return_value=_mock_response("ok")):
             from hacker_news.llm.litellm import call_litellm
             call_litellm("content", "prompt")
             self.assertNotIn("api_key", litellm.completion.call_args[1])
 
-    @patch("hacker_news.llm.litellm.sanitize_for_openai", side_effect=lambda c, **kw: c)
-    def test_empty_content_returns_empty(self, _mock_sanitize):
+    def test_empty_content_returns_empty(self):
         import litellm
         with patch.object(litellm, "completion", return_value=_empty_response()):
             from hacker_news.llm.litellm import call_litellm
             self.assertEqual(call_litellm("content", "prompt"), "")
 
-    @patch("hacker_news.llm.litellm.sanitize_for_openai", side_effect=lambda c, **kw: c)
-    def test_no_choices_returns_empty(self, _mock_sanitize):
+    def test_no_choices_returns_empty(self):
         import litellm
         with patch.object(litellm, "completion", return_value=_no_choices_response()):
             from hacker_news.llm.litellm import call_litellm
             self.assertEqual(call_litellm("content", "prompt"), "")
 
-    @patch("hacker_news.llm.litellm.sanitize_for_openai", side_effect=lambda c, **kw: c)
-    def test_think_tags_stripped(self, _mock_sanitize):
+    def test_think_tags_stripped(self):
         import litellm
         with patch.object(litellm, "completion", return_value=_mock_response("<think>reasoning</think>The actual summary.")):
             from hacker_news.llm.litellm import call_litellm
@@ -111,8 +103,7 @@ class LiteLLMProviderTestCase(TestCase):
             self.assertNotIn("think", result)
             self.assertIn("actual summary", result)
 
-    @patch("hacker_news.llm.litellm.sanitize_for_openai", side_effect=lambda c, **kw: c)
-    def test_auth_error_raises(self, _mock_sanitize):
+    def test_auth_error_raises(self):
         import litellm
         with patch.object(litellm, "completion",
                           side_effect=litellm.AuthenticationError(message="Invalid key", model="test", llm_provider="openai")):
@@ -120,8 +111,7 @@ class LiteLLMProviderTestCase(TestCase):
             with self.assertRaises(litellm.AuthenticationError):
                 call_litellm("content", "prompt")
 
-    @patch("hacker_news.llm.litellm.sanitize_for_openai", side_effect=lambda c, **kw: c)
-    def test_rate_limit_raises(self, _mock_sanitize):
+    def test_rate_limit_raises(self):
         import litellm
         with patch.object(litellm, "completion",
                           side_effect=litellm.RateLimitError(message="Rate limited", model="test", llm_provider="openai")):
@@ -129,8 +119,7 @@ class LiteLLMProviderTestCase(TestCase):
             with self.assertRaises(litellm.RateLimitError):
                 call_litellm("content", "prompt")
 
-    @patch("hacker_news.llm.litellm.sanitize_for_openai", side_effect=lambda c, **kw: c)
-    def test_timeout_raises(self, _mock_sanitize):
+    def test_timeout_raises(self):
         import litellm
         with patch.object(litellm, "completion",
                           side_effect=litellm.Timeout(message="Timed out", model="test", llm_provider="openai")):
@@ -145,8 +134,7 @@ class LiteLLMProviderTestCase(TestCase):
         with self.assertRaises(ValueError):
             call_litellm("content", "prompt")
 
-    @patch("hacker_news.llm.litellm.sanitize_for_openai", side_effect=lambda c, **kw: c)
-    def test_markdown_stripped(self, _mock_sanitize):
+    def test_markdown_stripped(self):
         import litellm
         with patch.object(litellm, "completion", return_value=_mock_response("**Bold** summary.")):
             from hacker_news.llm.litellm import call_litellm

--- a/test/test_litellm_provider.py
+++ b/test/test_litellm_provider.py
@@ -1,0 +1,158 @@
+# coding: utf-8
+"""Tests for the LiteLLM provider module.
+Run standalone: python -m pytest test/test_litellm_provider.py -v --override-ini='pythonpath=.'
+"""
+import sys
+import types
+import unittest
+from unittest import TestCase, mock
+from unittest.mock import MagicMock, patch
+
+# Stub heavy deps that break on Python 3.12 before any test imports
+_null_mod = types.ModuleType("null")
+_null_mod.Null = type("Null", (), {})
+sys.modules.setdefault("null", _null_mod)
+
+
+def _mock_response(content="Test summary", role="assistant"):
+    resp = MagicMock()
+    resp.model_dump.return_value = {
+        "choices": [{"message": {"role": role, "content": content}, "finish_reason": "stop"}],
+        "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+    }
+    return resp
+
+
+def _empty_response():
+    resp = MagicMock()
+    resp.model_dump.return_value = {"choices": [{"message": {"role": "assistant", "content": None}}]}
+    return resp
+
+
+def _no_choices_response():
+    resp = MagicMock()
+    resp.model_dump.return_value = {"choices": []}
+    return resp
+
+
+class LiteLLMProviderTestCase(TestCase):
+
+    def setUp(self):
+        import config
+        config.litellm_model = "openai/gpt-4o-mini"
+        config.litellm_api_key = ""
+
+    @patch("hacker_news.llm.litellm.sanitize_for_openai", side_effect=lambda c, **kw: c)
+    def test_basic_summarize(self, _mock_sanitize):
+        import litellm
+        with patch.object(litellm, "completion", return_value=_mock_response("Scientists discovered a new particle.")):
+            from hacker_news.llm.litellm import summarize_by_litellm
+            result = summarize_by_litellm("Some long article about physics...")
+            self.assertIn("particle", result)
+            litellm.completion.assert_called_once()
+            call_kwargs = litellm.completion.call_args[1]
+            self.assertEqual(call_kwargs["model"], "openai/gpt-4o-mini")
+
+    @patch("hacker_news.llm.litellm.sanitize_for_openai", side_effect=lambda c, **kw: c)
+    def test_translate_system_prompt(self, _mock_sanitize):
+        import litellm
+        with patch.object(litellm, "completion", return_value=_mock_response("Translated text")):
+            from hacker_news.llm.litellm import translate_by_litellm
+            translate_by_litellm("Some text", "simplified Chinese")
+            sys_msg = litellm.completion.call_args[1]["messages"][0]
+            self.assertIn("simplified Chinese", sys_msg["content"])
+
+    @patch("hacker_news.llm.litellm.sanitize_for_openai", side_effect=lambda c, **kw: c)
+    def test_drop_params_always_true(self, _mock_sanitize):
+        import litellm
+        with patch.object(litellm, "completion", return_value=_mock_response("ok")):
+            from hacker_news.llm.litellm import call_litellm
+            call_litellm("content", "system prompt")
+            self.assertTrue(litellm.completion.call_args[1]["drop_params"])
+
+    @patch("hacker_news.llm.litellm.sanitize_for_openai", side_effect=lambda c, **kw: c)
+    def test_api_key_forwarded(self, _mock_sanitize):
+        import config
+        config.litellm_api_key = "sk-test-key"
+        import litellm
+        with patch.object(litellm, "completion", return_value=_mock_response("ok")):
+            from hacker_news.llm.litellm import call_litellm
+            call_litellm("content", "prompt")
+            self.assertEqual(litellm.completion.call_args[1]["api_key"], "sk-test-key")
+
+    @patch("hacker_news.llm.litellm.sanitize_for_openai", side_effect=lambda c, **kw: c)
+    def test_api_key_omitted_when_empty(self, _mock_sanitize):
+        import litellm
+        with patch.object(litellm, "completion", return_value=_mock_response("ok")):
+            from hacker_news.llm.litellm import call_litellm
+            call_litellm("content", "prompt")
+            self.assertNotIn("api_key", litellm.completion.call_args[1])
+
+    @patch("hacker_news.llm.litellm.sanitize_for_openai", side_effect=lambda c, **kw: c)
+    def test_empty_content_returns_empty(self, _mock_sanitize):
+        import litellm
+        with patch.object(litellm, "completion", return_value=_empty_response()):
+            from hacker_news.llm.litellm import call_litellm
+            self.assertEqual(call_litellm("content", "prompt"), "")
+
+    @patch("hacker_news.llm.litellm.sanitize_for_openai", side_effect=lambda c, **kw: c)
+    def test_no_choices_returns_empty(self, _mock_sanitize):
+        import litellm
+        with patch.object(litellm, "completion", return_value=_no_choices_response()):
+            from hacker_news.llm.litellm import call_litellm
+            self.assertEqual(call_litellm("content", "prompt"), "")
+
+    @patch("hacker_news.llm.litellm.sanitize_for_openai", side_effect=lambda c, **kw: c)
+    def test_think_tags_stripped(self, _mock_sanitize):
+        import litellm
+        with patch.object(litellm, "completion", return_value=_mock_response("<think>reasoning</think>The actual summary.")):
+            from hacker_news.llm.litellm import call_litellm
+            result = call_litellm("content", "prompt")
+            self.assertNotIn("think", result)
+            self.assertIn("actual summary", result)
+
+    @patch("hacker_news.llm.litellm.sanitize_for_openai", side_effect=lambda c, **kw: c)
+    def test_auth_error_raises(self, _mock_sanitize):
+        import litellm
+        with patch.object(litellm, "completion",
+                          side_effect=litellm.AuthenticationError(message="Invalid key", model="test", llm_provider="openai")):
+            from hacker_news.llm.litellm import call_litellm
+            with self.assertRaises(litellm.AuthenticationError):
+                call_litellm("content", "prompt")
+
+    @patch("hacker_news.llm.litellm.sanitize_for_openai", side_effect=lambda c, **kw: c)
+    def test_rate_limit_raises(self, _mock_sanitize):
+        import litellm
+        with patch.object(litellm, "completion",
+                          side_effect=litellm.RateLimitError(message="Rate limited", model="test", llm_provider="openai")):
+            from hacker_news.llm.litellm import call_litellm
+            with self.assertRaises(litellm.RateLimitError):
+                call_litellm("content", "prompt")
+
+    @patch("hacker_news.llm.litellm.sanitize_for_openai", side_effect=lambda c, **kw: c)
+    def test_timeout_raises(self, _mock_sanitize):
+        import litellm
+        with patch.object(litellm, "completion",
+                          side_effect=litellm.Timeout(message="Timed out", model="test", llm_provider="openai")):
+            from hacker_news.llm.litellm import call_litellm
+            with self.assertRaises(litellm.Timeout):
+                call_litellm("content", "prompt")
+
+    def test_missing_model_raises(self):
+        import config
+        config.litellm_model = ""
+        from hacker_news.llm.litellm import call_litellm
+        with self.assertRaises(ValueError):
+            call_litellm("content", "prompt")
+
+    @patch("hacker_news.llm.litellm.sanitize_for_openai", side_effect=lambda c, **kw: c)
+    def test_markdown_stripped(self, _mock_sanitize):
+        import litellm
+        with patch.object(litellm, "completion", return_value=_mock_response("**Bold** summary.")):
+            from hacker_news.llm.litellm import call_litellm
+            result = call_litellm("content", "prompt")
+            self.assertNotIn("**", result)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

Add **LiteLLM** as a native summarization and translation provider, giving hacker-news-digest access to 100+ LLM providers (Anthropic, Google, Azure, Bedrock, Groq, Ollama, and more) through `litellm.completion()`.


## Motivation

The current setup requires an OpenAI-compatible API key. Users who want Claude, Gemini, Bedrock, or local models need a separate proxy. LiteLLM lets users point at any provider natively by setting `LITELLM_MODEL=anthropic/claude-sonnet-4-6`. Also relates to #35 where you mentioned using free OpenRouter models - LiteLLM supports those natively too.

## Changes

- `hacker_news/llm/litellm.py` - New provider with `summarize_by_litellm()` and `translate_by_litellm()`
- `hacker_news/news.py` - Added litellm dispatch (tried before OpenAI, falls through if `LITELLM_MODEL` not set)
- `config.py` - Added `LITELLM_MODEL` and `LITELLM_API_KEY` env var config
- `db/summary.py` - Added `LITELLM` to `Model` enum with `is_final` and `need_escape` flags
- `requirements.txt` - Added `litellm>=1.83.0,<2.0`
- `test/test_litellm_provider.py` - 13 unit tests

## Implementation details

- Uses `litellm.completion()` directly with `drop_params=True` for cross-provider compatibility
- Separate cleanup functions for summarize vs translate: `_clean_summary()` strips leading non-alphanumeric chars (English output), `_clean_translation()` preserves CJK/non-Latin characters
- Does NOT depend on `sanitize_for_openai()` from the openai module (avoids `openai.api_base` crash on newer SDK versions)
- Specific exception handling: `AuthenticationError`, `NotFoundError` propagate immediately; `RateLimitError`, `Timeout`, `APIConnectionError` propagate for caller retry logic
- Empty responses (null content, empty choices) return `''` gracefully
- Lazy import so the module loads without litellm installed

## Bugs caught during E2E testing

1. **`sanitize_for_openai` SDK crash** - The openai module's `sanitize_for_openai()` reads `openai.api_base` which doesn't exist in openai SDK v1+. Replaced with standalone `_truncate_content()`.
2. **CJK translation destroyed** - The cleanup regex `re.sub(r'^[^a-zA-Z0-9]+', '', answer)` strips all leading non-ASCII characters, destroying Chinese/Japanese/Korean translations entirely. Fixed by using separate `_clean_translation()` that preserves non-Latin text.

## Tests

**13 unit tests covering:**
- Summarize and translate dispatch with correct system prompts
- `drop_params=True` always present
- API key forwarded when set, omitted when empty (env var fallback)
- Empty content, empty choices return `''`
- `<think>` tags stripped from reasoning models
- Auth error, rate limit, timeout propagate correctly
- Missing `LITELLM_MODEL` raises `ValueError`
- Markdown `**` stripped from output

**Live E2E (Anthropic via Azure Foundry):**
```
>>> summarize_by_litellm("Researchers at MIT developed solar cells printable on fabric...")
'MIT researchers created lightweight, flexible solar cells printable on
 fabric that generate power from indoor light. This technology could
 enable clothing that charges personal devices.'

>>> translate_by_litellm(summary, "simplified Chinese")
'麻省理工学院的研究人员开发出一种轻薄、柔性的太阳能电池，可以直接印刷在织物上，
 将便携性与可再生能源发电相结合。'
```

## Example usage

```python
import os
os.environ["LITELLM_MODEL"] = "anthropic/claude-sonnet-4-6"
os.environ["ANTHROPIC_API_KEY"] = "sk-ant-..."

from hacker_news.llm.litellm import summarize_by_litellm, translate_by_litellm

summary = summarize_by_litellm("Long article text here...")
print(summary)

translation = translate_by_litellm(summary, "simplified Chinese")
print(translation)
```

```bash
# Direct SDK usage (no proxy needed, litellm routes to provider)
export LITELLM_MODEL=anthropic/claude-sonnet-4-6
export ANTHROPIC_API_KEY=sk-ant-...
python publish.py
```

```bash
# Or with a self-hosted LiteLLM proxy (uses whatever models the proxy exposes)
export LITELLM_MODEL=my-claude          # model name from your proxy config
export LITELLM_API_KEY=sk-proxy-key     # proxy auth key if configured
export LITELLM_API_BASE=http://my-gateway:4000
python publish.py
```

## Risk / Compatibility

- Additive only - existing OpenAI, Coze, Llama, T5 providers untouched
- If `LITELLM_MODEL` is not set, litellm provider is skipped entirely - zero behavior change
- LiteLLM handles provider API key resolution from standard env vars
